### PR TITLE
Remove config_location{Extra,Provider}PackageNames

### DIFF
--- a/rro_overlays/PixelFrameworkOverlay/res/values/arrays.xml
+++ b/rro_overlays/PixelFrameworkOverlay/res/values/arrays.xml
@@ -3,11 +3,4 @@
     <string-array name="config_keep_warming_services">
         <item>com.google.android.GoogleCamera/com.google.android.apps.camera.prewarm.NoOpPrewarmService</item>
     </string-array>
-    <string-array name="config_locationExtraPackageNames">
-        <item>com.google.android.gms.location.history</item>
-    </string-array>
-    <string-array name="config_locationProviderPackageNames">
-        <item>com.google.android.gms</item>
-        <item>com.android.location.fused</item>
-    </string-array>
 </resources>


### PR DESCRIPTION
vendor/lineage/overlay/common/frameworks/base/core/res/res/values/config.xml (https://github.com/Evolution-X/vendor_evolution/blob/bka/overlay/common/frameworks/base/core/res/res/values/config.xml#L36) provided a more complete list of packages, but are overwritten by the values here.
