### PR TITLE
pixel-style: Do not override qualified networks service

### DIFF
--- a/rro_overlays/Pixelframework-res/res/values-ar-rXB-feminine/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-ar-rXB-feminine/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(F)‏‮com.android.qns‬‏</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-ar-rXB-masculine/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-ar-rXB-masculine/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(M)‏‮com.android.qns‬‏</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-ar-rXB-neuter/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-ar-rXB-neuter/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(N)‏‮com.android.qns‬‏</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-ar-rXB/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-ar-rXB/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">‏‮com.android.qns‬‏</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-en-rXA-feminine/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-en-rXA-feminine/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(F)[çöḿ.åñðŕöîð.Qñš one two three]</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-en-rXA-masculine/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-en-rXA-masculine/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(M)[çöḿ.åñðŕöîð.Qñš one two three]</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-en-rXA-neuter/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-en-rXA-neuter/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">(N)[çöḿ.åñðŕöîð.Qñš one two three]</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values-en-rXA/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values-en-rXA/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="config_qualified_networks_service_package">[çöḿ.åñðŕöîð.Qñš one two three]</string>
 </resources>

--- a/rro_overlays/Pixelframework-res/res/values/strings.xml
+++ b/rro_overlays/Pixelframework-res/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="config_deviceProvisioningPackage">com.google.android.apps.work.oobconfig</string>
-    <string name="config_qualified_networks_service_package">com.android.qns</string>
     <string name="config_wallpaperCropperPackage">com.google.android.apps.wallpaper</string>
 </resources>


### PR DESCRIPTION
Pixelframework-res is a generic product RRO, but it forced qualified networks service package to com.android.qns. Devices such as sm8150-common provide a device overlay for vendor.qti.iwlan and may not ship com.android.qns, so the generic override makes telephony bind a missing service.

Drop the generic QNS package override and let device overlays choose the correct service.